### PR TITLE
Add AlgoVoi multi-chain payment gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ The Stellar Consensus Protocol (SCP) provides a way to reach consensus without r
 
 - [Skyhitz](https://skyhitz.io/) - Skyhitz is a beats market for music creators built on Stellar. 
 
-- [AlgoVoi](https://algovoi.co.uk/) - Multi-chain, multi-protocol crypto payment gateway. Accepts USDC on Stellar via Circle-issued assets with SEP-friendly memo binding (`av:{token}` short-memo format to fit MEMO_TEXT's 28-byte limit). Also spans Algorand, VOI, Hedera, Base, Solana, and Tempo on a single endpoint. Implements Coinbase x402, IETF MPP, and Google AP2 agent-commerce protocols. Hosted checkout pages + on-chain verification + open-source adapters for 17+ eCommerce platforms.
+- [AlgoVoi](https://algovoi.co.uk/) - Multi-chain crypto payment gateway accepting Circle-issued USDC on Stellar, with `av:{token[:20]}` MEMO_TEXT binding (truncated to fit Stellar's 28-byte limit) for on-chain payment verification.
 
 ## Stellar Asset Issuers (Anchors)
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ The Stellar Consensus Protocol (SCP) provides a way to reach consensus without r
 
 - [Skyhitz](https://skyhitz.io/) - Skyhitz is a beats market for music creators built on Stellar. 
 
+- [AlgoVoi](https://algovoi.co.uk/) - Multi-chain, multi-protocol crypto payment gateway. Accepts USDC on Stellar via Circle-issued assets with SEP-friendly memo binding (`av:{token}` short-memo format to fit MEMO_TEXT's 28-byte limit). Also spans Algorand, VOI, Hedera, Base, Solana, and Tempo on a single endpoint. Implements Coinbase x402, IETF MPP, and Google AP2 agent-commerce protocols. Hosted checkout pages + on-chain verification + open-source adapters for 17+ eCommerce platforms.
+
 ## Stellar Asset Issuers (Anchors)
 
 - [AnchorUSD](https://www.anchorusd.com/) - Redeemable and stable cryptocurrency anchored 1-for-1 to the US dollar. All deposits are secured in US-domiciled bank accounts.


### PR DESCRIPTION
Adds AlgoVoi to the *Projects Building on Stellar* section.

## Stellar integration
AlgoVoi accepts on-chain USDC on Stellar via the Circle-issued asset (\`USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN\`). Stellar is a first-class chain on the facilitator - not an afterthought. Notable Stellar-specific design choices:

- **Short-memo binding** - each payment link stores a memo_note_prefix of the form \`av:{token[:20]}\` designed to fit Stellar's MEMO_TEXT 28-byte limit. Most memo-based binding implementations for multi-chain gateways forget this constraint; AlgoVoi handles it in the link-creation path.
- **Credit-asset support** - handles the compound \`CODE:ISSUER\` asset identifier natively, including path_payment and fee-bump verification.
- **SEP-friendly** - verifier uses the public Horizon endpoint; no private anchor infrastructure required. Merchants can accept XLM or any SEP-24 credit asset.

## Broader context
AlgoVoi is multi-chain (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo) so merchants don't pick just one network; all 7 can be offered on the same hosted checkout with automatic routing by tenant preference. Agents can pay via Coinbase x402, IETF MPP, or Google AP2 - all three at the same URL.

## Live references
- Agent card: https://api.algovoi.co.uk/.well-known/agent.json
- Hosted checkout sample: https://api.algovoi.co.uk/checkout/
- Open-source MCP adapter + eCommerce plugins: https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters

## Scope of change
Single-line addition to \`Projects Building on Stellar\`. No other sections touched.

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*