### PR TITLE
Add Monitoring & Status Pages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Network Statistics](#network-statistics)
 - [Developer Resources](#developer-resources)
 - [Developer Educational Resources](#developer-educational-resources)
+- [Monitoring & Status Pages](#monitoring--status-pages)
 - [Understanding the Stellar Consensus Protocol](#understanding-the-stellar-consensus-protocol)
 - [Projects Building on Stellar](#projects-building-on-stellar)
 - [Stellar Asset Issuers (Anchors)](#stellar-asset-issuers-anchors)
@@ -273,6 +274,10 @@ If you're new to Stellar start here 👇
     - [ZkVM: about the motocrab](https://youtu.be/1i-EJykVzag) 
     - [User-Friendly Key Management with SEP-30 Recoverysigner](https://youtu.be/W-n73Cuy7-0) 
     - [Turing Complete Contract proposal for Stellar](https://youtu.be/T7FlHKbew4U) 
+
+## Monitoring & Status Pages
+
+ - [StatusPageBuddy](https://www.statuspagebuddy.com/) - Free hosted status pages for indie developers. No credit card required; custom branding and domain available on the free plan.
 
 ## Understanding the Stellar Consensus Protocol
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ If you're new to Stellar start here 👇
 
 ## Monitoring & Status Pages
 
- - [StatusPageBuddy](https://www.statuspagebuddy.com/) - Free hosted status pages for indie developers. No credit card required; custom branding and domain available on the free plan.
+- [StatusPageBuddy](https://www.statuspagebuddy.com/) - Free hosted status pages for indie developers. 
 
 ## Understanding the Stellar Consensus Protocol
 


### PR DESCRIPTION
Adding a new "Monitoring & Status Pages" section.                                    
                                                               
**Why a new section**: There's no existing place for tools that help developers communicate uptime to users of apps built on Stellar. "Network Statistics" covers monitoring the Stellar chain itself; this fills the project-side gap.                
                                                               
**Demand signal**: In the past 7 days alone, multiple Stellar ecosystem projects have opened public status-page issues, including
[Stellar-Fluid/fluid#616](https://github.com/Stellar-Fluid/fluid/issues/616), [soyaya/Cross-Border-Payment-Router-on-Stellar#76](https://github.com/soyaya/Cross-Border-Payment-Router-on-Stellar/issues/76), and [chioma-housing-protocol-I/chioma#955](https://github.com/chioma-housing-protocol-I/chioma/issues/955).

**Entry**: One entry to start the section, per the one-link-per-PR guideline. Happy  to follow up with additional tools (open-source options like Upptime/Cachet, hosted options like Atlassian Statuspage) in separate PRs if the section structure is welcome.                                                     

**Disclosure**: I maintain StatusPageBuddy.                                          