### PR TITLE
Fix CBDC resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you're new to Stellar start here 👇
 
 - [Onboarding everyone - the StellarX Mission](https://youtu.be/HNRmJMAJ5rw)
 
-- [Central Bank Digital Currencies](http://thinktank.omfif.org/ibm)
+- [Central Bank Digital Currencies](https://www.omfif.org/omfif-reports/central-bank-digital-currencies/)
 
 - [Charting the Evolution of Programmable Money](https://www.ibm.com/thought-leadership/institute-business-value/report/programmoneyevo)
 


### PR DESCRIPTION
## Summary
- replace the stale OMFIF thinktank CBDC URL with the current OMFIF report page

## Verification
- confirmed the new OMFIF report URL returns HTTP 200
- confirmed the old HTTPS thinktank URL returns 404

Closes #30